### PR TITLE
[URT-4] : fix(profile.html):  NoneType' object has no attribute 'id'

### DIFF
--- a/django/ft_transcendence/core/profile_utils.py
+++ b/django/ft_transcendence/core/profile_utils.py
@@ -1,0 +1,20 @@
+from django.contrib.auth.decorators import login_required
+from chat.models import Chat
+from django.db.models import Q
+
+
+@login_required
+def get_or_create_chat(request, chatWithUser):
+	refUser = request.user
+
+	chat = Chat.objects.filter(
+			Q(fromUser=refUser, toUser=chatWithUser) |
+			Q(fromUser=chatWithUser, toUser=refUser)
+		).first()
+
+	if not chat:
+		print("No chat yet")
+		chat = Chat.objects.create(fromUser=request.user, toUser=chatWithUser)
+
+	print("Chat exists")
+	return chat


### PR DESCRIPTION
**Description**:
This error occurs when a user attempts to create a chat that doesn't exist. The issue arises because `Chat.objects.create(fromUser=request.user, toUser=chatWithUser)` doesn't capture the new Chat instance. As a result, the function returns None, leading to a 'NoneType has no attribute id' error.

**Fix**:
Assign the result of Chat.objects.create() to a variable and return that variable when no chat is found, ensuring the chat instance is properly handled.