### PR TITLE
[CT-18] Fix UserID doesn't exists in URL 

### DIFF
--- a/django/ft_transcendence/chat/consumers.py
+++ b/django/ft_transcendence/chat/consumers.py
@@ -39,7 +39,6 @@ class ChatConsumer(WebsocketConsumer):
         for message in messages:
             result.append(self.message_to_json(message))
 
-        print(f"result : {result}")
         return result
 
     def message_to_json(self, message):

--- a/django/ft_transcendence/chat/views.py
+++ b/django/ft_transcendence/chat/views.py
@@ -14,10 +14,17 @@ def index(request):
 
 @login_required
 def room(request, room_name, userID):
+    user_chats = Chat.get_user_chats(request.user)
+    last_user_message = Chat.get_user_chats(request.user).last().toUser.id
+    try:
+        User.objects.get(id=userID)
+    except User.DoesNotExist as e:
+        return redirect('chat:get_room_redirect', userID=last_user_message)
+
+
     from_user = request.user.id
     to_user   = User.objects.get(id=userID)
     user_profile = User.objects.get(id=userID)
-    user_chats = Chat.get_user_chats(request.user)
 
     context = {
         "room_name": room_name,


### PR DESCRIPTION
**Issue:**
Exception Value: User matching query does not exist.
In /django/ft_transcendence/chat/views.py
        `to_user   = User.objects.get(id=userID)`
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^

**How:**
User enter manually an userID in `views.room` that does not exists leading to an exception value.

**Solution:**
Try block that catch the exception and call `get_room_redirect` with the last_user_message