### PR TITLE
[NOT-3] [NOT-5] Friend Request Notification and isRead Message

### DIFF
--- a/django/ft_transcendence/chat/consumers.py
+++ b/django/ft_transcendence/chat/consumers.py
@@ -8,6 +8,18 @@ from django.contrib.auth.models import User
 
 class ChatConsumer(WebsocketConsumer):
 
+    def mark_as_read(self, chat_id):
+        # Assuming you have a way to fetch the chat and messages
+        chat = Chat.objects.get(id=chat_id)
+        message = chat.message_set.order_by('createdAt').last()
+
+        print(f"message : {message.message}")
+        if message and message.message_receiver == self.user:
+            message.isRead = True
+            message.save()
+
+        # return render(request, 'chat/chat_room.html', {'chat': chat})
+
     def fetch_messages(self, data):
         messages = Message.get_all_messages_from_chat(self.room_name)
         content = {
@@ -17,15 +29,16 @@ class ChatConsumer(WebsocketConsumer):
         self.send_message(content)
 
     def new_message(self, data):
-        author = data['from']
-        author_user = User.objects.filter(username=author)[0]
+        author_user = User.objects.get(username=data['author'])
+        receiver    = User.objects.get(username=data['receiver'])
         chat = Chat.objects.get(id=self.room_name)
         message = Message.objects.create(
             author=author_user,
+            message_receiver=receiver,
             message=data['message'],
             refChat=chat
         )
-        print(f"data from {data['from']}")
+
         content = {
             'command': 'new_message',
             'message': self.message_to_json(message)
@@ -55,14 +68,19 @@ class ChatConsumer(WebsocketConsumer):
 
     def connect(self):
         try:
-            user = self.scope['user']
-            print("=== user %s" % user)
-            if str(user)=="AnonymousUser":
+            self.user = self.scope['user']
+            print("=== user %s" % self.user)
+            if str(self.user)=="AnonymousUser":
                 print("==Not authorized")
                 return
             self.room_name = self.scope['url_route']['kwargs']['room_name']
-            self.user_id = self.scope['url_route']['kwargs']['user_id']
+            # self.user_id = self.scope['url_route']['kwargs']['user_id']
             chat = Chat.objects.get(id=self.room_name)
+            if chat.fromUser == self.user:
+                self.user_id = chat.toUser
+            else:
+                self.user_id = chat.fromUser
+            self.mark_as_read(chat.id)
             self.room_group_name = 'chat_%s' % str(chat.id)
             # Join room group
             async_to_sync(self.channel_layer.group_add)(

--- a/django/ft_transcendence/chat/models.py
+++ b/django/ft_transcendence/chat/models.py
@@ -20,8 +20,8 @@ class Chat(models.Model):
     def __str__(self):
         return u'%s - %s' % (self.fromUser,self.toUser)
 
-    def get_all_chat(fromUser):
-        return Chat.objects.filter(fromUser=fromUser)
+    def get_all_chats(user):
+        return Chat.objects.filter(Q(fromUser=user) | Q(toUser=user))
 
     # @classmethod
     def get_last_message(chat):

--- a/django/ft_transcendence/chat/models.py
+++ b/django/ft_transcendence/chat/models.py
@@ -65,6 +65,8 @@ class Chat(models.Model):
 
 class Message(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    author = models.ForeignKey(User, db_index=True, related_name='author', on_delete=models.SET_NULL,null=True)
+    message_receiver = models.ForeignKey(User, db_index=True, related_name='message_receiver', on_delete=models.SET_NULL,null=True)
     refChat = models.ForeignKey(Chat, db_index=True,on_delete=models.CASCADE)
     message = models.TextField()
     msg_type = (
@@ -74,7 +76,6 @@ class Message(models.Model):
     )
     type = models.IntegerField(choices=msg_type, default=0)
     extraData = models.CharField(default='', null=True, blank=True, max_length=255)
-    author = models.ForeignKey(User, db_index=True, related_name='author', on_delete=models.SET_NULL,null=True)
     isRead = models.BooleanField(default=False)
     createdAt = models.DateTimeField(auto_now_add=True)
     updatedAt = models.DateTimeField(auto_now=True)

--- a/django/ft_transcendence/chat/models.py
+++ b/django/ft_transcendence/chat/models.py
@@ -23,8 +23,9 @@ class Chat(models.Model):
     def get_all_chat(fromUser):
         return Chat.objects.filter(fromUser=fromUser)
 
-    def get_last_message(fromUser):
-        return Chat.message_set.last()
+    # @classmethod
+    def get_last_message(chat):
+        return chat.message_set.last()
 
     @classmethod
     def reverse_query_set(cls, user, querySet):

--- a/django/ft_transcendence/chat/routing.py
+++ b/django/ft_transcendence/chat/routing.py
@@ -3,5 +3,5 @@ from django.urls import re_path
 from . import consumers
 
 websocket_urlpatterns = [
-    re_path(r'ws/chat/(?P<room_name>[-a-zA-Z0-9_]+)/(?P<user_id>\d+)/', consumers.ChatConsumer.as_asgi()),
+    re_path(r'ws/chat/(?P<room_name>[-a-zA-Z0-9_]+)', consumers.ChatConsumer.as_asgi()),
 ]

--- a/django/ft_transcendence/chat/static/chat/js/chat.js
+++ b/django/ft_transcendence/chat/static/chat/js/chat.js
@@ -19,11 +19,10 @@ chatSocket.onmessage = function(e) {
 	const data = JSON.parse(e.data);
 	if (data['command'] === 'messages') {
 		for (let i = 0; i < data['messages'].length; i++) {
-			console.log(`from : ${data['messages'][i].author}`)
 			createMessage(data['messages'][i], data['messages'][i].author);
 		}
 	} else if (data['command'] === 'new_message') {
-		createMessage(data['message'], data['message'].author);
+			createMessage(data['message'], data['message'].author);
 	}
 };
 

--- a/django/ft_transcendence/chat/static/chat/js/chat.js
+++ b/django/ft_transcendence/chat/static/chat/js/chat.js
@@ -8,7 +8,7 @@ console.log(senderUsername);
 console.log(roomName)
 
 const chatSocket = new WebSocket(
-	'ws://' + window.location.host + '/ws/chat/' + roomName + '/' + userID + '/'
+	'ws://' + window.location.host + '/ws/chat/' + roomName
 );
 
 chatSocket.onopen = function(e) {
@@ -44,9 +44,9 @@ document.querySelector('#chat-message-submit').onclick = function(e) {
 	chatSocket.send(JSON.stringify({
 		"message": message,
 		"command": "new_message",
-		"from": senderUsername,
+		"author": senderUsername,
+		"receiver": receiverUsername,
 		"refChat": roomName,
-		"author": userID,
 		"type": 0,
 		"extraData": ""
 	}));

--- a/django/ft_transcendence/chat/views.py
+++ b/django/ft_transcendence/chat/views.py
@@ -7,6 +7,7 @@ import json
 from django.utils.safestring import mark_safe
 from .chat_utils import get_or_create_chat
 from django.shortcuts import redirect
+from django.views.decorators.csrf import csrf_exempt
 
 @login_required
 def index(request):
@@ -27,11 +28,10 @@ def room(request, room_name, userID):
 
     from_user = request.user.id
     to_user   = User.objects.get(id=userID)
-    user_profile = User.objects.get(id=userID)
 
     context = {
         "room_name": room_name,
-        "userID": to_user.id,
+        "userID": to_user.username,
         "sender_username": request.user.username,
         "receiver_username": to_user.username,
         "user_chats": user_chats

--- a/django/ft_transcendence/core/models.py
+++ b/django/ft_transcendence/core/models.py
@@ -40,8 +40,9 @@ class FriendRequest(models.Model):
 
 # One Notification per User.
 class Notification(models.Model):
-    user            = models.OneToOneField(User, related_name="notification_user", on_delete=models.CASCADE)
-    friend_request  = models.ForeignKey(FriendRequest, related_name="friend_request", on_delete=models.CASCADE)
-    message         = models.ForeignKey(Message, related_name="message_notification", on_delete=models.CASCADE)
-    chat            = models.ForeignKey(Chat, related_name="chat", on_delete=models.CASCADE)
+    receiver        = models.ForeignKey(User, null=True, related_name="notification_receiver", on_delete=models.CASCADE)
+    sender          = models.ForeignKey(User, null=True, related_name="notification_sender", on_delete=models.CASCADE)
+    friend_request  = models.ForeignKey(FriendRequest, null=True, related_name="notification_friend_request", on_delete=models.CASCADE)
+    message         = models.ForeignKey(Message, null=True, related_name="message_notification", on_delete=models.CASCADE)
+    chat            = models.ForeignKey(Chat, null=True, related_name="chat", on_delete=models.CASCADE)
     total_notifs    = models.IntegerField(default=0)

--- a/django/ft_transcendence/core/models.py
+++ b/django/ft_transcendence/core/models.py
@@ -5,17 +5,17 @@ from django.db.models.signals import post_save
 from django import forms
 from django.contrib import admin
 from django.contrib.auth.models import User
-
+from chat.models import Chat, Message
 
 # Tips :
 #  -Django can't have two reverse query names that are the same \
 #   To prevent this behavior we use <related_name> to have unique "reverse query name" \
 class UserProfile(models.Model):
-    user   = models.OneToOneField(User, on_delete=models.CASCADE) # Here
-    avatar = models.ImageField(upload_to="avatars/", default="avatar.png")
-    victory = models.IntegerField(default=0)
-    defeat = models.IntegerField(default=0)
-    friends = models.ManyToManyField(User, blank=True, related_name="userprofile_friends") # And here
+    user         = models.OneToOneField(User, on_delete=models.CASCADE) # Here
+    avatar       = models.ImageField(upload_to="avatars/", default="avatar.png")
+    victory      = models.IntegerField(default=0)
+    defeat       = models.IntegerField(default=0)
+    friends      = models.ManyToManyField(User, blank=True, related_name="userprofile_friends") # And here
     blocked_user = models.ManyToManyField(User, blank=True, related_name="blocked_user")
     list_display = ['user', 'avatar']  # Customize fields to display
 
@@ -31,9 +31,17 @@ def save_user_profile(sender, instance, **kwargs):
 # Many-to-One (ForeignKey)
 class FriendRequest(models.Model):
     # Who sent the request
-    sender = models.ForeignKey(User, related_name="sender", on_delete=models.CASCADE)
+    sender      = models.ForeignKey(User, related_name="sender", on_delete=models.CASCADE)
     # Who receive the request
-    receiver   = models.ForeignKey(User, related_name= "receiver", on_delete=models.CASCADE)
+    receiver    = models.ForeignKey(User, related_name= "receiver", on_delete=models.CASCADE)
 
     # def __str__(self):
     #     return f"FriendRequest from {self.sender.username} to {self.receiver.username}"
+
+# One Notification per User.
+class Notification(models.Model):
+    user            = models.OneToOneField(User, related_name="notification_user", on_delete=models.CASCADE)
+    friend_request  = models.ForeignKey(FriendRequest, related_name="friend_request", on_delete=models.CASCADE)
+    message         = models.ForeignKey(Message, related_name="message_notification", on_delete=models.CASCADE)
+    chat            = models.ForeignKey(Chat, related_name="chat", on_delete=models.CASCADE)
+    total_notifs    = models.IntegerField(default=0)

--- a/django/ft_transcendence/core/models.py
+++ b/django/ft_transcendence/core/models.py
@@ -41,7 +41,6 @@ class FriendRequest(models.Model):
 # One Notification per User.
 class Notification(models.Model):
     receiver        = models.ForeignKey(User, null=True, related_name="notification_receiver", on_delete=models.CASCADE)
-    sender          = models.ForeignKey(User, null=True, related_name="notification_sender", on_delete=models.CASCADE)
     friend_request  = models.ForeignKey(FriendRequest, null=True, related_name="notification_friend_request", on_delete=models.CASCADE)
     message         = models.ForeignKey(Message, null=True, related_name="message_notification", on_delete=models.CASCADE)
     chat            = models.ForeignKey(Chat, null=True, related_name="chat", on_delete=models.CASCADE)

--- a/django/ft_transcendence/core/static/core/css/media-queries/social_media-queries-height.css
+++ b/django/ft_transcendence/core/static/core/css/media-queries/social_media-queries-height.css
@@ -9,7 +9,7 @@
     .social-bar--line{
         display: none;
     }
-    
+
     /* ----- Container for one user ----- */
     .social--each-user-profile-container{
         padding: 8px 20px; /* padding between text and border */
@@ -28,7 +28,7 @@
     .social--each-user-profile-container a {
         font-size: 16px;
     }
-	
+
 	/* ----- Buttons Chat + Game Container ----- */
 	.social--user-profile-buttons{
 		margin: 5px;

--- a/django/ft_transcendence/core/static/core/css/notifications.css
+++ b/django/ft_transcendence/core/static/core/css/notifications.css
@@ -61,6 +61,7 @@
 }
 
 .notification {
+	display: flex;
 	background-color: rgba(25,0,56, 0.5);
 	text-align: center;
 	justify-content: center;
@@ -70,4 +71,19 @@
 	margin: 5%;
 	width: 90%;
 	height: 10%;
+}
+
+.notif-user-avatar-img {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    margin-right: 3%;
+	margin-left: 2%;
+	margin-top: 1%;
+}
+
+.notif-text {
+    margin-top: 0.8%;
+	flex: 1;
+    text-align: left;
 }

--- a/django/ft_transcendence/core/static/core/css/notifications.css
+++ b/django/ft_transcendence/core/static/core/css/notifications.css
@@ -33,3 +33,41 @@
 	border-radius: 50%;
 	transform: translateX(-50%);
 }
+
+.notification_container {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	/* margin: 10%; */
+	/* margin-bottom: 10%; */
+	width: 100%;
+	height: 100%;
+}
+
+.black-box {
+	/* display: flex; */
+    /* justify-content: center;
+    align-items: center; */
+    background: rgba(0, 0, 0, 0.5);
+    border-radius: 10px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+    /* padding: 20px; */
+    /* max-width: 400px; */
+    width: 80%;
+    height: 80%;
+    text-align: center;
+    overflow-y: scroll;
+
+}
+
+.notification {
+	background-color: rgba(25,0,56, 0.5);
+	text-align: center;
+	justify-content: center;
+	color : white;
+	font-size: 300%;
+	padding-top: 1%;
+	margin: 5%;
+	width: 90%;
+	height: 10%;
+}

--- a/django/ft_transcendence/core/static/core/css/notifications.css
+++ b/django/ft_transcendence/core/static/core/css/notifications.css
@@ -1,21 +1,19 @@
 .notifs {
 	position: relative;
-	display: inline-block;
-	border-bottom: 1px dotted black;
-  }
+	max-width: 10px;
+	left: 95%;
+}
 
-  .notifs .notifstext {
+.notifstext {
 	visibility: hidden;
-	width: 300px;
 	background-color: black;
 	color: #fff;
 	text-align: center;
 	border-radius: 6px;
-	padding: 5px 0;
-
+	width: 200px;
 	/* Position the notifs */
 	position: absolute;
-	left : 100%;
+	right : 100%;
 	z-index: 1;
   }
 
@@ -26,12 +24,10 @@
 .alert_notifs {
 	position: absolute;
 	top: -10%;
-	left: 100%;
 	width: 20px;
 	height: 20px;
 	background-color: orange;
 	border-radius: 50%;
-	transform: translateX(-50%);
 }
 
 .notification_container {
@@ -83,6 +79,9 @@
 }
 
 .notif-text {
+	display: flex;
+    gap: 2%;
+	align-items: center;
     margin-top: 0.8%;
 	flex: 1;
     text-align: left;

--- a/django/ft_transcendence/core/static/core/css/notifications.css
+++ b/django/ft_transcendence/core/static/core/css/notifications.css
@@ -1,0 +1,35 @@
+.notifs {
+	position: relative;
+	display: inline-block;
+	border-bottom: 1px dotted black;
+  }
+
+  .notifs .notifstext {
+	visibility: hidden;
+	width: 300px;
+	background-color: black;
+	color: #fff;
+	text-align: center;
+	border-radius: 6px;
+	padding: 5px 0;
+
+	/* Position the notifs */
+	position: absolute;
+	left : 100%;
+	z-index: 1;
+  }
+
+  .notifs:hover .notifstext {
+	visibility: visible;
+  }
+
+.alert_notifs {
+	position: absolute;
+	top: -10%;
+	left: 100%;
+	width: 20px;
+	height: 20px;
+	background-color: orange;
+	border-radius: 50%;
+	transform: translateX(-50%);
+}

--- a/django/ft_transcendence/core/static/core/css/social.css
+++ b/django/ft_transcendence/core/static/core/css/social.css
@@ -42,7 +42,7 @@
 	.buttons-active{
 		color: #1A003E; /* text color */
 		background: linear-gradient(to right, #DC91C2, #EEC881); /* background color */
-		transition: .5s; 
+		transition: .5s;
 	}
 
 	/* Search User Field Design */
@@ -116,7 +116,7 @@
 		100% {
 			width: 48%;
 		}
-	}	
+	}
 
 	/* ----- Full Friend list Container ----- */
 	.social--display-list{
@@ -170,7 +170,7 @@
 		justify-content: center;
 		padding-bottom: 21px;
 	}
-	
+
 	/* ----- Buttons Chat + Game Container ----- */
 	.social--user-profile-buttons{
 		display: flex;
@@ -202,3 +202,24 @@
 		font-size: 14px;
 		color: white;
 	}
+
+.exception {
+	position: fixed;
+	top: 20px;
+	right: 20px;
+	background-color: #444;
+	color: #fff;
+	padding: 10px 20px;
+	border-radius: 5px;
+	box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+	opacity: 0;
+	transition: opacity 0.5s ease-in-out;
+}
+
+.exception.show {
+	opacity: 1;
+}
+
+.exception.hidden {
+	display: none;
+}

--- a/django/ft_transcendence/core/static/core/js/social.js
+++ b/django/ft_transcendence/core/static/core/js/social.js
@@ -1,0 +1,76 @@
+// Get all buttons with the "social-bar--buttons" class
+const socialButtons = document.querySelectorAll('.social-bar--buttons');
+
+// Get the Friends button specifically
+const friendsButton = document.querySelector('.social-bar--friends .social-bar--buttons');
+
+// Get the container where the information will be displayed
+const infoContainer = document.getElementById('infoContainer');
+
+// Function to load the corresponding template based on button click
+function loadContent(templateId) {
+	const template = document.getElementById(templateId);
+	if (template) {
+		// Clone template's content and display it in the container
+		const content = template.content.cloneNode(true);
+		infoContainer.innerHTML = ''; // Clear existing content
+		infoContainer.appendChild(content); // Add new content to the container
+	}
+}
+
+// Function to handle button clicks and update the content
+function handleButtonClick(event) {
+	// Remove 'buttons-active' class from all buttons and reset images
+	socialButtons.forEach(button => {
+		button.classList.remove('buttons-active');
+		const imgElement = button.querySelector('img');
+		const originalSrc = button.getAttribute('data-img-original');
+		if (imgElement && originalSrc) {
+			imgElement.src = originalSrc;
+		}
+	});
+
+	// Add 'buttons-active' class to clicked button and update image
+	const clickedButton = event.currentTarget;
+	clickedButton.classList.add('buttons-active');
+	const imgElement = clickedButton.querySelector('img');
+	const clickedImgSrc = clickedButton.getAttribute('data-img-clicked');
+	if (imgElement && clickedImgSrc) {
+		imgElement.src = clickedImgSrc;
+		imgElement.classList.add('icons-logos');
+	}
+
+	// Load the corresponding template based on data-info attribute
+	const dataType = clickedButton.getAttribute('data-info');
+	if (dataType === 'all_friends') {
+		loadContent('all-friends-template');
+	} else if (dataType === 'pending_requests') {
+		loadContent('pending-requests-template');
+	} else if (dataType === 'blocked_users') {
+		loadContent('blocked-users-template');
+	}
+}
+
+// Store original image source for each button and add click listeners
+socialButtons.forEach(button => {
+	const imgElement = button.querySelector('img');
+	if (imgElement) {
+		button.setAttribute('data-img-original', imgElement.src);
+	}
+	button.addEventListener('click', handleButtonClick);
+});
+
+// Load the Friends section by default on page load and mark the button as active
+window.addEventListener('DOMContentLoaded', () => {
+	loadContent('all-friends-template'); // Load Friends content
+	friendsButton.classList.add('buttons-active'); // Mark Friends button as active
+
+	// Change Friends button image to clicked version
+	const imgElement = friendsButton.querySelector('img');
+	const clickedImgSrc = friendsButton.getAttribute('data-img-clicked');
+	if (imgElement && clickedImgSrc) {
+		imgElement.src = clickedImgSrc;
+		imgElement.classList.add('icons-logos');
+	}
+});
+

--- a/django/ft_transcendence/core/static/core/js/social_utils.js
+++ b/django/ft_transcendence/core/static/core/js/social_utils.js
@@ -1,0 +1,12 @@
+function showNotification(message) {
+    const exception = document.getElementById('exception');
+    exception.textContent = message;
+    exception.classList.remove('hidden');
+    exception.classList.add('show');
+
+    // Hide after 5 seconds
+    setTimeout(() => {
+        exception.classList.remove('show');
+        setTimeout(() => exception.classList.add('hidden'), 500); // Allow transition to complete
+    }, 5000);
+}

--- a/django/ft_transcendence/core/templates/core/home.html
+++ b/django/ft_transcendence/core/templates/core/home.html
@@ -14,10 +14,10 @@
 <body>
 
     <!---------- Background Video ---------->
-    <!-- <video autoplay muted loop class="video-background">
+    <video autoplay muted loop class="video-background">
         <source src="{% static 'core/images/planet-background.mp4' %}" type="video/mp4">
         Your browser does not support the video tag.
-    </video> -->
+    </video>
 
     <div class="welcome-box">
 

--- a/django/ft_transcendence/core/templates/core/home.html
+++ b/django/ft_transcendence/core/templates/core/home.html
@@ -1,7 +1,6 @@
 {% load socialaccount %}
 {% load static %}
 {% include 'core/sidenav.html' %}
-{% if user.is_authenticated %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -9,6 +8,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="{% static 'core/css/home.css' %}">
+    <link rel="stylesheet" href="{% static 'core/css/notifications.css' %}">
     <link rel="stylesheet" href="{% static 'css/main.css' %}">
 </head>
 <body>
@@ -20,11 +20,7 @@
     </video> -->
 
     <div class="welcome-box">
-        <div class="notification">
-            {% for friend_request in friend_requests %}
-                <h1> Request received from {{ friend_request }} </h1>
-            {% endfor %}
-        </div>
+
         <div class="white-box">
             <div class="welcome-message">
                 <h1>Welcome {{ user.username }}!</h1>
@@ -38,17 +34,21 @@
         </div>
     </div>
 
+    <div>
+        <div class="notifs">
+            {% if total_notifs > 0 %}
+                <div class="alert_notifs"></div>
+            {% endif %}
+            <span class="notifstext">You have unread notifications.</span>
+            <a href="{% url 'core:notifications' %}" class="buttons-design btn-notifs">
+                {{ total_notifs }}
+            </a>
+            </button>
+          </div>
+    </div>
+    {% for friend_request in friend_requests %}
+        <h1> Request received from {{ friend_request.sender }} </h1>
+    {% endfor %}
+    </div>
 </body>
 </html>
-
-{% else %}
-
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0">
-    <title>Redirecting...</title>
-</head>
-</html>
-{% endif %}

--- a/django/ft_transcendence/core/templates/core/home.html
+++ b/django/ft_transcendence/core/templates/core/home.html
@@ -19,8 +19,19 @@
         Your browser does not support the video tag.
     </video>
 
-    <div class="welcome-box">
+    <div class="notifs">
+        {% if total_notifs > 0 %}
+            <div class="alert_notifs"></div>
+            <span class="notifstext">You have unread notifications.</span>
+        {% endif %}
+        <a href="{% url 'core:notifications' %}" class="buttons-design btn-notifs">
+            {{ total_notifs }}
+        </a>
+        </button>
+    </div>
 
+
+    <div class="welcome-box">
         <div class="white-box">
             <div class="welcome-message">
                 <h1>Welcome {{ user.username }}!</h1>
@@ -32,23 +43,6 @@
                 </form>
             </div>
         </div>
-    </div>
-
-    <div>
-        <div class="notifs">
-            {% if total_notifs > 0 %}
-                <div class="alert_notifs"></div>
-            {% endif %}
-            <span class="notifstext">You have unread notifications.</span>
-            <a href="{% url 'core:notifications' %}" class="buttons-design btn-notifs">
-                {{ total_notifs }}
-            </a>
-            </button>
-          </div>
-    </div>
-    {% for friend_request in friend_requests %}
-        <h1> Request received from {{ friend_request.sender }} </h1>
-    {% endfor %}
     </div>
 </body>
 </html>

--- a/django/ft_transcendence/core/templates/core/notifications.html
+++ b/django/ft_transcendence/core/templates/core/notifications.html
@@ -24,7 +24,13 @@
 				{% for notification in notifications %}
 					{% if notification.friend_request.sender %}
 						<div class="notification">
-							request received from {{ notification.friend_request.sender }}
+							<img	src="{{ notification.friend_request.sender.userprofile.avatar.url }}"
+									alt="User Avatar"
+									class="notif-user-avatar-img"/>
+							<span class="notif-text">Request received from
+								<a href="/profile/{{ notification.friend_request.sender }}">  {{notification.friend_request.sender}}
+							</a>
+							</span>
 						</div>
 					{% endif %}
 				{% endfor %}

--- a/django/ft_transcendence/core/templates/core/notifications.html
+++ b/django/ft_transcendence/core/templates/core/notifications.html
@@ -8,6 +8,7 @@
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<link rel="stylesheet" href="{% static 'core/css/home.css' %}">
+		<link rel="stylesheet" href="{% static 'core/css/social.css' %}">
 		<link rel="stylesheet" href="{% static 'core/css/notifications.css' %}">
 		<link rel="stylesheet" href="{% static 'css/main.css' %}">
 	</head>
@@ -27,10 +28,17 @@
 							<img	src="{{ notification.friend_request.sender.userprofile.avatar.url }}"
 									alt="User Avatar"
 									class="notif-user-avatar-img"/>
-							<span class="notif-text">Request received from
-								<a href="/profile/{{ notification.friend_request.sender }}">  {{notification.friend_request.sender}}
-							</a>
-							</span>
+							<div class="notif-text">Request received from
+								<a href="/profile/{{ notification.friend_request.sender }}">  {{notification.friend_request.sender}}</a>
+								<button type="submit" class="buttons-design">
+									<a href="{% url 'core:accept_friend_request' notification.friend_request.id %}"> Accept
+									</a>
+								</button>
+								<button type="submit" class="buttons-design">
+									<a href="{% url 'core:decline_friend_request' notification.friend_request.id %}"> Deny
+									</a>
+								</button>
+							</div>
 						</div>
 					{% endif %}
 				{% endfor %}

--- a/django/ft_transcendence/core/templates/core/notifications.html
+++ b/django/ft_transcendence/core/templates/core/notifications.html
@@ -1,0 +1,22 @@
+{% load socialaccount %}
+{% load static %}
+{% include 'core/sidenav.html' %}
+
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<link rel="stylesheet" href="{% static 'core/css/home.css' %}">
+		<link rel="stylesheet" href="{% static 'css/main.css' %}">
+	</head>
+
+	<body>
+		<!---------- Background Video ---------->
+		<video autoplay muted loop class="video-background">
+			<source src="{% static 'core/images/planet-background.mp4' %}" type="video/mp4">
+			Your browser does not support the video tag.
+		</video>
+
+	</body>
+</html>

--- a/django/ft_transcendence/core/templates/core/notifications.html
+++ b/django/ft_transcendence/core/templates/core/notifications.html
@@ -8,6 +8,7 @@
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<link rel="stylesheet" href="{% static 'core/css/home.css' %}">
+		<link rel="stylesheet" href="{% static 'core/css/notifications.css' %}">
 		<link rel="stylesheet" href="{% static 'css/main.css' %}">
 	</head>
 
@@ -18,5 +19,15 @@
 			Your browser does not support the video tag.
 		</video>
 
+		<div class="notification_container">
+			<div class="black-box">
+				{% for notification in notifications %}
+					{% if notification.friend_request.sender %}
+						<div class="notification">
+							request received from {{ notification.friend_request.sender }}
+						</div>
+					{% endif %}
+				{% endfor %}
+		</div>
 	</body>
 </html>

--- a/django/ft_transcendence/core/templates/core/notifications.html
+++ b/django/ft_transcendence/core/templates/core/notifications.html
@@ -40,6 +40,16 @@
 								</button>
 							</div>
 						</div>
+					{% elif notification.message %}
+						<div class="notification">
+							<div class="notif-text">
+								<img	src="{{ notification.message.author.userprofile.avatar.url }}"
+										alt="User Avatar"
+										class="notif-user-avatar-img"/>
+								Message from
+								{{ notification.message.author }} : {{ notification.message.message }}
+							</div>
+						</div>
 					{% endif %}
 				{% endfor %}
 		</div>

--- a/django/ft_transcendence/core/templates/core/sidenav.html
+++ b/django/ft_transcendence/core/templates/core/sidenav.html
@@ -12,9 +12,9 @@
 
 <div id="SidenavID" class="sidenav">
 	<a href="javascript:void(0)" class="closebtn" onclick="closeNav(); openMenu()">&times;</a>
-	<a href="/home/">Home</a>
-	<a href="/my_profile/">Profile</a>
-	<a href="/social/">Social</a>
+	<a href="{% url 'core:home' %}">Home</a>
+	<a href="{% url 'core:my_profile' %}">Profile</a>
+	<a href="{% url 'core:social' %}">Social</a>
 	<a href=" {% url 'chat:direct_message' %}">Chat</a>
 	<a href="#">Game Stats</a>
 	<a href="{% url 'core:logout' %}">Logout</a>

--- a/django/ft_transcendence/core/templates/core/social.html
+++ b/django/ft_transcendence/core/templates/core/social.html
@@ -26,12 +26,14 @@
             Your browser does not support the video tag.
         </video>
 
-        <script>
-            document.addEventListener('DOMContentLoaded', function() {
-                showNotification("{{ exception_value }}");
-            });
-        </script>
-        <div id="exception" class="exception hidden"> {{ exception_value }} </div>
+        {% if exception_value %}
+            <div id="exception" class="exception hidden"> {{ exception_value }} </div>
+            <script>
+                document.addEventListener('DOMContentLoaded', function() {
+                    showNotification("{{ exception_value }}");
+                });
+            </script>
+        {% endif %}
 
         <!---------- Social Buttons on top of the page ---------->
         <div class="social-bar">

--- a/django/ft_transcendence/core/templates/core/social.html
+++ b/django/ft_transcendence/core/templates/core/social.html
@@ -17,6 +17,7 @@
 </head>
 
 <body class="scroll">
+    <script src="{% static 'core/js/social_utils.js' %}"></script>
     <!---------- Global container for layout management ---------->
     <div class="container">
         <!---------- Background Video ---------->
@@ -24,6 +25,13 @@
             <source src="{% static 'core/images/planet-background.mp4' %}" type="video/mp4">
             Your browser does not support the video tag.
         </video>
+
+        <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                showNotification("{{ exception_value }}");
+            });
+        </script>
+        <div id="exception" class="exception hidden"> {{ exception_value }} </div>
 
         <!---------- Social Buttons on top of the page ---------->
         <div class="social-bar">
@@ -178,148 +186,7 @@
         </template>
     </div>
 
-    <script>
+    <script src="{% static 'core/js/social.js' %}"></script>
 
-        // Get all buttons with the "social-bar--buttons" class
-        const socialButtons = document.querySelectorAll('.social-bar--buttons');
-        
-        // Get the Friends button specifically
-        const friendsButton = document.querySelector('.social-bar--friends .social-bar--buttons');
-    
-        // Get the container where the information will be displayed
-        const infoContainer = document.getElementById('infoContainer');
-    
-        // Function to load the corresponding template based on button click
-        function loadContent(templateId) {
-            const template = document.getElementById(templateId);
-            if (template) {
-                // Clone template's content and display it in the container
-                const content = template.content.cloneNode(true);
-                infoContainer.innerHTML = ''; // Clear existing content
-                infoContainer.appendChild(content); // Add new content to the container
-            }
-        }
-    
-        // Function to handle button clicks and update the content
-        function handleButtonClick(event) {
-            // Remove 'buttons-active' class from all buttons and reset images
-            socialButtons.forEach(button => {
-                button.classList.remove('buttons-active');
-                const imgElement = button.querySelector('img');
-                const originalSrc = button.getAttribute('data-img-original');
-                if (imgElement && originalSrc) {
-                    imgElement.src = originalSrc;
-                }
-            });
-    
-            // Add 'buttons-active' class to clicked button and update image
-            const clickedButton = event.currentTarget;
-            clickedButton.classList.add('buttons-active');
-            const imgElement = clickedButton.querySelector('img');
-            const clickedImgSrc = clickedButton.getAttribute('data-img-clicked');
-            if (imgElement && clickedImgSrc) {
-                imgElement.src = clickedImgSrc;
-                imgElement.classList.add('icons-logos');
-            }
-    
-            // Load the corresponding template based on data-info attribute
-            const dataType = clickedButton.getAttribute('data-info');
-            if (dataType === 'all_friends') {
-                loadContent('all-friends-template');
-            } else if (dataType === 'pending_requests') {
-                loadContent('pending-requests-template');
-            } else if (dataType === 'blocked_users') {
-                loadContent('blocked-users-template');
-            }
-        }
-    
-        // Store original image source for each button and add click listeners
-        socialButtons.forEach(button => {
-            const imgElement = button.querySelector('img');
-            if (imgElement) {
-                button.setAttribute('data-img-original', imgElement.src);
-            }
-            button.addEventListener('click', handleButtonClick);
-        });
-    
-        // Load the Friends section by default on page load and mark the button as active
-        window.addEventListener('DOMContentLoaded', () => {
-            loadContent('all-friends-template'); // Load Friends content
-            friendsButton.classList.add('buttons-active'); // Mark Friends button as active
-    
-            // Change Friends button image to clicked version
-            const imgElement = friendsButton.querySelector('img');
-            const clickedImgSrc = friendsButton.getAttribute('data-img-clicked');
-            if (imgElement && clickedImgSrc) {
-                imgElement.src = clickedImgSrc;
-                imgElement.classList.add('icons-logos');
-            }
-        });
-    </script>
-    
-    
-        <!-- <script>
-            // Get all buttons with the "social-bar--buttons" class
-            const socialButtons = document.querySelectorAll('.social-bar--buttons');
-
-            // Get the container where informations will be displayed
-            const infoContainer = document.getElementById('infoContainer');
-
-            // Loop through the buttons and add the same click event listener to each
-            socialButtons.forEach(button => {
-                button.addEventListener('click', function() {
-                    // Récupérer les informations stockées dans l'attribut "data-info"
-                    const info = button.getAttribute('data-info');
-                    socialButtons.forEach(btn => btn.classList.remove('hidden'));
-                    socialButtons.forEach(btn => btn.classList.add('social-bar--buttons'));
-
-                    // Afficher les informations dans le conteneur
-                    infoContainer.textContent = info;
-                });
-            });
-        </script>
-
-        <div class="search-user">
-            <h1>Welcome, {{ user.username }}</h1>
-            <form action="/social/" method="post" class="form-box">
-                {% csrf_token %}
-                {{ search_form.as_p }}
-                <input type="submit" value="Search" class="submit-button">
-            </form>
-
-            {% if not user_found %}
-                <p class="error-message">The user <strong>{{ searched_username }}</strong> could not be found.</p>
-            {% endif %}
-
-            <div class="section">
-                <h2>Available Friend Requests</h2>
-                <ul class="friend-list">
-                    {% for friend_request in available_friend_request %}
-                        <li>{{ friend_request.username }} <a href="/send_friend_request/{{ friend_request.id }}">Send Friend Request</a></li>
-                    {% endfor %}
-                </ul>
-            </div>
-
-                        <div class="social-bar--remove-friends">
-                            <button type="submit" class="social-bar--buttons">
-                                Remove
-                                <div class="friend-list hidden social-bar--buttons">
-                                {% for friend in all_friends %}
-                                    <li>Remove <a href="/remove_friend/{{ friend.id }}">{{ friend.username }}</a></li>
-                                {% endfor %}
-                                </div>
-                            </button>
-                        </div>
-            -->
-            <!-- <div class="section">
-                <h2>All Users</h2>
-                <ul class="friend-list">
-                    {% for db_user in all_users %}
-                        {% if not db_user.is_superuser and db_user != user %}
-                            <li class="block-user">Block <a href="/block_user/{{ db_user.id }}">{{ db_user.username }}</a></li>
-                        {% endif %}
-                    {% endfor %}
-                </ul>
-            </div> -->
 </body>
 </html>

--- a/django/ft_transcendence/core/templates/core/user_profile.html
+++ b/django/ft_transcendence/core/templates/core/user_profile.html
@@ -72,6 +72,11 @@
                             </button>
                             {% elif received_friend_request %}
                             <button type="submit" class="social--user-profile-buttons-design buttons-design">
+                                <a href="{% url 'core:accept_friend_request' received_friend_request.id %}">
+                                    Accept Friend Request <img src="{% static 'core/images/accept-logo.png'%}" class="social--buttons-section-logos">
+                                </a>
+                            </button>
+                            <button type="submit" class="social--user-profile-buttons-design buttons-design">
                                 <a href="{% url 'core:decline_friend_request' received_friend_request.id %}">
                                     Decline Friend Request <img src="{% static 'core/images/decline-logo.png'%}" class="social--buttons-section-logos">
                                 </a>

--- a/django/ft_transcendence/core/templates/core/user_profile.html
+++ b/django/ft_transcendence/core/templates/core/user_profile.html
@@ -89,6 +89,11 @@
                                     <span> Message </span>
                                 </button>
                             </form>
+                            <button type="submit" class="profile--buttons buttons-design">
+                                <a href="{% url 'core:remove_friend' user_profile.id %}">
+                                    Remove this friend <img src="{% static 'core/images/decline-logo.png'%}" class="social--buttons-section-logos">
+                                </a>
+                            </button>
                         </div>
                         {% else %}
                         <div class="add-friend">

--- a/django/ft_transcendence/core/urls.py
+++ b/django/ft_transcendence/core/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
 	path("cancel_friend_request/<int:userID>/", views.cancel_friend_request, name="cancel_friend_request"),
 	path("remove_friend/<int:friendID>/", views.remove_friend, name="remove_friend"),
 	path("block_user/<int:userID>/", views.block_user, name="block_user"),
+	path("notifications/", views.notifications, name="notifications"),
 	path("unblock_user/<int:userID>/", views.unblock_user, name="unblock_user")
 
 ]

--- a/django/ft_transcendence/core/utils/social_utils.py
+++ b/django/ft_transcendence/core/utils/social_utils.py
@@ -6,6 +6,7 @@ from django.contrib.auth.decorators import login_required
 from django.views.decorators.cache import never_cache
 from django.shortcuts import render
 from chat.models import Chat
+from core.models import Notification
 
 def	user_profile(request, search_user_form):
 	searched_username = search_user_form.cleaned_data["username"]
@@ -54,7 +55,13 @@ def send_friend_request(request, userID):
     sender = request.user
     receiver   = User.objects.get(id=userID)
     friend_request, created = FriendRequest.objects.get_or_create(
-        sender=sender, receiver=receiver)
+        sender=sender, receiver=receiver
+    )
+    Notification.objects.get_or_create(
+        receiver=receiver,
+        friend_request=friend_request
+    )
+
     if created:
         previous_url = request.META.get('HTTP_REFERER', '/')
         return HttpResponseRedirect(previous_url)

--- a/django/ft_transcendence/core/utils/social_utils.py
+++ b/django/ft_transcendence/core/utils/social_utils.py
@@ -7,6 +7,7 @@ from django.views.decorators.cache import never_cache
 from django.shortcuts import render
 from chat.models import Chat
 from core.models import Notification
+from django.urls import reverse
 
 def	user_profile(request, search_user_form):
 	searched_username = search_user_form.cleaned_data["username"]
@@ -90,15 +91,16 @@ def accept_friend_request(request, friendRequestID):
 
 # Decline friend request that has been received.
 # Ensuring that the request has been sent from the logged-user.
-# TRY BLOCK NEEDED
 @login_required
 @never_cache
 def decline_friend_request(request, friendRequestID):
-    friend_request = FriendRequest.objects.get(id=friendRequestID)
+    try:
+        friend_request = FriendRequest.objects.get(id=friendRequestID)
+    except Exception as e:
+        request.session['exception_value'] = "No Friend Request exists"
+        return redirect(reverse('core:social'))
 
-    print(f'friend request id : {friendRequestID}')
     if friend_request and friend_request.receiver == request.user or friend_request.sender == request.user:
-        print("DELETING")
         friend_request.delete()
     previous_url = request.META.get('HTTP_REFERER', '/')
     return HttpResponseRedirect(previous_url)

--- a/django/ft_transcendence/core/views.py
+++ b/django/ft_transcendence/core/views.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 # ---- Authentication -------------------
 from django.contrib.auth.models import User
-from .models import FriendRequest
+from .models import FriendRequest, Notification
 
 # ---- Forms ----------------------------
 from .forms import (
@@ -163,4 +163,13 @@ def social(request, searched_username="", user_found=True):
 @login_required
 @never_cache
 def notifications(request):
-    return render(request, "core/notifications.html")
+    notifications = request.user.notification_receiver.all()
+
+    context = {
+        "notifications": notifications
+    }
+
+    print(f"notifications : {notifications}")
+    for notification in notifications:
+        print(notification.friend_request.sender)
+    return render(request, "core/notifications.html", context)

--- a/django/ft_transcendence/core/views.py
+++ b/django/ft_transcendence/core/views.py
@@ -77,10 +77,16 @@ def logout(request):
 @login_required
 @never_cache
 def home(request):
-    received_friend_requests = request.user.receiver.values_list('sender__username')
+    friend_requests = request.user.receiver.all()
+    total_notifs     = 0
 
+    for total_notifs in range(len(friend_requests)):
+        total_notifs += 1
+
+    print(f"total notif : {total_notifs}")
     context = {
-        "friend_requests": received_friend_requests
+        "friend_requests": friend_requests,
+        "total_notifs": total_notifs
     }
     return render(request, "core/home.html", context)
 
@@ -126,9 +132,6 @@ def profile(request, username):
     room_name = chat.id
     all_users = User.objects.all()
 
-    print(f"received_friend_request : {received_friend_request}")
-    print(f"sent_friend_request     : {sent_friend_request}")
-    print(f"username                : {username}")
     context = {
         "all_users": all_users,
         "user_profile": user_profile,
@@ -157,3 +160,7 @@ def social(request, searched_username="", user_found=True):
     context['user_found'] = user_found
     return render(request, "core/social.html", context)
 
+@login_required
+@never_cache
+def notifications(request):
+    return render(request, "core/notifications.html")

--- a/django/ft_transcendence/core/views.py
+++ b/django/ft_transcendence/core/views.py
@@ -147,6 +147,7 @@ def profile(request, username):
 @login_required
 @never_cache
 def social(request, searched_username="", user_found=True):
+
     context = get_social_data(request)
     search_user_form = SearchUser(prefix="search")
     if request.method == "POST":
@@ -155,6 +156,12 @@ def social(request, searched_username="", user_found=True):
             return user_profile(request, search_user_form)
         else:
             return redirect("/home/")
+
+
+    exception_value = request.session.pop('exception_value', None)
+    if exception_value:
+        # Handle or display the exception value
+        context['exception_value'] = exception_value
 
     context['search_form'] = search_user_form
     context['user_found'] = user_found


### PR DESCRIPTION
### Features :
- A box at the top right with the total number of notifications have been added, redirecting to the **notification page**.
- The **notification page** actually contains all friends requests that has been received with the possibility to accept or deny the Friend Request directly in this page. 
- No excuse, your partner will see if you have **read** the **message** (not yet but soon). All unread **messages** will be in the (tabababadam) **notification page**  Woohoo !
- Add **Exception System Value**. Don't be afraid it's just a little notification that will disappear after 5 seconds if not everything went as planned :) Example : send a request to be a friend, stay on this page. On the same time your request has been denied (oh so sad), and you want to cancel this request because you know that you are too good to be friend with this person.
No panic, this situation is handled 🙂
- Add buttons to accept or deny friend request on user_profile page (yes this button is on social page, notif page and user_profile page).

⚠️ These features have not been adequately checked and may need further attention. 